### PR TITLE
Update NTLM.php

### DIFF
--- a/library/SSRS/Soap/NTLM.php
+++ b/library/SSRS/Soap/NTLM.php
@@ -132,7 +132,7 @@ class NTLM extends \SoapClient {
         curl_setopt($handle, CURLOPT_HTTPAUTH, CURLAUTH_NTLM);
 
         $headers = array(
-            'Method: ' . ($data === null) ? 'GET' : 'POST',
+            'Method: ' . (($data === null) ? 'GET' : 'POST'),
             'Connection: Keep-Alive',
             'User-Agent: PHP-SOAP-CURL',
         );


### PR DESCRIPTION
There is precedence issue occurring with this ternary in later versions of PHP.  Suggest wrapping in brackets to ensure the ternary stays self-contained.
