### PR TITLE
Update Report.php

### DIFF
--- a/library/SSRS/Report.php
+++ b/library/SSRS/Report.php
@@ -456,7 +456,8 @@ class Report {
         $options = array(
             'username' => $this->_username,
             'password' => $this->_passwd,
-            'cache_wsdl_path' => $this->options['cache_wsdl_path']
+            'cache_wsdl_path' => $this->options['cache_wsdl_path'],
+        	'curlopt_cainfo' => isset($this->options['curlopt_cainfo']) ? $this->options['curlopt_cainfo'] : null,  
         );
 
         $client = new SoapNTLM($this->_baseUri . '/' . $path, $options);


### PR DESCRIPTION
SSL Support
If the array $options in constructor contains "curlopt_cainfo" (path to crt file) this options will be provided to class NTLM
