### PR TITLE
cache_wsdl_path changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "breakoutbox/php-ssrs",
-    "description": "PHP library for connecting to SSRS SOAP (fork)",
+    "name": "chartblocks/php-ssrs",
+    "description": "PHP library for connecting to SSRS SOAP",
     "license": "MIT",
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "chartblocks/php-ssrs",
-    "description": "PHP library for connecting to SSRS SOAP",
+    "name": "breakoutbox/php-ssrs",
+    "description": "PHP library for connecting to SSRS SOAP (fork)",
     "license": "MIT",
     "authors": [
         {

--- a/library/SSRS/Soap/NTLM.php
+++ b/library/SSRS/Soap/NTLM.php
@@ -17,8 +17,11 @@ class NTLM extends \SoapClient {
 
     function __construct($wsdl, $options = array()) {
         if (empty($options['cache_wsdl_path'])) {
-            $options['cache_wsdl_path'] = '/tmp/' . md5($wsdl) . '.wsdl';
+            $options['cache_wsdl_path'] = sys_get_temp_dir();
         }
+        if(!preg_match('/'.preg_quote(DIRECTORY_SEPARATOR, '/').'$/', $options['cache_wsdl_path']))
+            $options['cache_wsdl_path'] .= DIRECTORY_SEPARATOR;
+        $options['cache_wsdl_path'] .= md5($wsdl) . '.wsdl';
 
         if (array_key_exists('username', $options)) {
             $this->setUsername($options['username']);

--- a/library/SSRS/Soap/NTLM.php
+++ b/library/SSRS/Soap/NTLM.php
@@ -87,8 +87,10 @@ class NTLM extends \SoapClient {
             throw new RuntimeException("WSDL cache file not writeable");
         } elseif (false === is_dir($folder)) {
             throw new RuntimeException("WSDL cache parent folder does not exist");
-        } elseif (false === is_writeable($folder)) {
+        } elseif (touch($folder.DIRECTORY_SEPARATOR.'test') === false) {
             throw new RuntimeException("WSDL cache parent folder not writeable");
+        } else {
+            unlink($folder . DIRECTORY_SEPARATOR . 'test');
         }
 
         $this->_cachePath = $file;


### PR DESCRIPTION
Thank you for this library.  It has saved me a lot of time.

I ran into one small issue while implementing this, however.  I am working under Windows, so the hard-coded /tmp default would not work for me.  I instead tried manually setting a 'cache_wsdl_path' in the options when constructing the Report object, however it seems this wants a single file name, not an alternative directory to store the cache files.

This would be fine, however, since there are 2 different wsdl files, one for "Service" and one for "Execution", setting a single file for this would cause both of these to try and use the same cached wsdl, thus causing errors that certain resources aren't available.  These are the errors I was encountering.  It appears you have considered this when using the default /tmp location (as you md5 the wsdl path to create a unique cache file), however when setting an override there was no way to differentiate the two.

This pull request changes this logic to instead look at sys_get_temp_dir() for the default temporary file location on the system.  And if you still want to override this by providing a 'cache_wsdl_path' option when constructing, then it treats it as a directory instead of a single file so that the 2 cache files can still be maintained separately.
