### PR TITLE
Add blank string check for XML responses

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,5 +27,10 @@
         "zendframework/zend-i18n": "Required for rendering forms with ZendFramework2",
         "zendframework/zend-servicemanager": "Required for rendering forms with ZendFramework2",
         "zendframework/zend-view": "Required for rendering forms with ZendFramework2"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0.x-dev"
+        }
     }
 }

--- a/library/SSRS/Soap/NTLM.php
+++ b/library/SSRS/Soap/NTLM.php
@@ -165,10 +165,12 @@ class NTLM extends \SoapClient {
         }
 
         $httpCode = curl_getinfo($handle, CURLINFO_HTTP_CODE);
-        if ($httpCode >= 300 && $httpCode <= 600) {
-            throw ServerException::fromResponse($response);
-        } else if ($httpCode !== 200) {
-            throw new Exception('HTTP error: ' . $httpCode . ' ' . $response, $httpCode, $response);
+        if ($httpCode !== 200) {
+            if ($response !== '' && $httpCode >= 300 && $httpCode <= 600) {
+                throw ServerException::fromResponse($response);
+            } else {
+                throw new Exception('HTTP error: ' . $httpCode . ' ' . $response, $httpCode, $response);
+            }
         }
         curl_close($handle);
 


### PR DESCRIPTION
Addresses #21, #22, #31 in its simplest form.

This does not add an expansion for more specific error messages as suggested on #21 (or using something like https://gist.github.com/henriquemoody/6580488), but that could be an interesting additional update later.

Also adds a branch alias to make it easier to do fork tests.